### PR TITLE
Expose RemoteEndpointIP through WaitOperation

### DIFF
--- a/Server/Core/Operations/CustomOperations/DownloadOperation.cs
+++ b/Server/Core/Operations/CustomOperations/DownloadOperation.cs
@@ -32,6 +32,7 @@ namespace Batzill.Server.Core.Operations
         protected override void ExecuteInternal(HttpContext context, IAuthenticationManager authManager)
         {
             context.Response.SetDefaultValues();
+            context.Response.SetHeaderValue("RemoteEndpointIp", context.Request.RemoteEndpoint.Address.ToString());
 
             this.logger?.Log(EventType.OperationInformation, "Got request to download data, try parsing size passed by client.");
 

--- a/Server/Core/Operations/CustomOperations/EchoOperation.cs
+++ b/Server/Core/Operations/CustomOperations/EchoOperation.cs
@@ -18,6 +18,7 @@ namespace Batzill.Server.Core.Operations
         protected override void ExecuteInternal(HttpContext context, IAuthenticationManager authManager)
         {
             context.Response.SetDefaultValues();
+            context.Response.SetHeaderValue("RemoteEndpointIp", context.Request.RemoteEndpoint.Address.ToString());
 
             // Create response content
             StringBuilder ss = new StringBuilder();

--- a/Server/Core/Operations/CustomOperations/WaitOperation.cs
+++ b/Server/Core/Operations/CustomOperations/WaitOperation.cs
@@ -5,8 +5,6 @@ using Batzill.Server.Core.Authentication;
 using Batzill.Server.Core.Exceptions;
 using Batzill.Server.Core.Logging;
 using Batzill.Server.Core.ObjectModel;
-using Batzill.Server.Core.Settings;
-using Batzill.Server.Core.Settings.Custom.Operations;
 
 namespace Batzill.Server.Core.Operations
 {
@@ -23,6 +21,7 @@ namespace Batzill.Server.Core.Operations
         protected override void ExecuteInternal(HttpContext context, IAuthenticationManager authManager)
         {
             context.Response.SetDefaultValues();
+            context.Response.SetHeaderValue("RemoteEndpointIp", context.Request.RemoteEndpoint.Address.ToString());
 
             this.logger?.Log(EventType.OperationInformation, "Got request to wait, try parsing seconds passed by client.");
 


### PR DESCRIPTION
**Summary:** Expose remote IP address as header in the response for WaitOperation, DownloadOperation and EchoOperation.